### PR TITLE
Relax pytz version requirement to support newer versions (>=2020.5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from volcengine import VERSION
 install_requires = [
     "requests>=2.25.1",
     "retry==0.9.2",
-    "pytz==2020.5",
+    "pytz>=2020.5",
     "pycryptodome==3.9.9",
     "protobuf>=3.18.3",
     "google>=3.0.0",


### PR DESCRIPTION
## Summary

This pull request relaxes the `pytz` dependency from `==2020.5` to `>=2020.5` in `setup.py`.

## Motivation

The strict `pytz==2020.5` constraint in `setup.py` causes dependency conflicts in modern Python environments, especially when other libraries require newer versions of `pytz` (e.g., `>=2025.1`). This prevents the SDK from being installed alongside many up-to-date packages.

## What Changed

- Updated `setup.py` to require `pytz>=2020.5` instead of locking it to `==2020.5`.

This change aligns `setup.py` with the more flexible constraint already present in `requirements.txt`, which specifies `pytz>=2020.5`. It helps ensure consistency across the project’s dependency declarations.

## Impact

This change allows users to use this SDK with newer `pytz` versions while still maintaining compatibility starting from version `2020.5`.

Thanks!