### PR TITLE
Deprecates misspelled method and introduces correct schema setter

### DIFF
--- a/volcengine/base/Request.py
+++ b/volcengine/base/Request.py
@@ -1,5 +1,6 @@
 # coding : utf-8
 from collections import OrderedDict
+import warnings
 
 try:
     from urllib import urlencode
@@ -20,8 +21,21 @@ class Request(object):
         self.connection_timeout = 0
         self.socket_timeout = 0
 
-    def set_shema(self, schema):
+    def set_schema(self, schema):
         self.schema = schema
+
+    def set_shema(self, schema):
+        """
+        Deprecated: Use set_schema() instead.
+        This method will be removed in a future version.
+        """
+        warnings.warn(
+            "set_shema() is deprecated due to a typo and will be removed in a future version. "
+            "Use set_schema() instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        self.set_schema(schema)
 
     def set_method(self, method):
         self.method = method

--- a/volcengine/base/Service.py
+++ b/volcengine/base/Service.py
@@ -113,7 +113,7 @@ class Service(object):
 
         mquery = self.merge(api_info.query, params)
         r = Request()
-        r.set_shema(self.service_info.scheme)
+        r.set_schema(self.service_info.scheme)
         r.set_method(api_info.method)
         r.set_path(api_info.path)
         r.set_query(mquery)
@@ -225,7 +225,7 @@ class Service(object):
         socket_timeout = self.service_info.socket_timeout
 
         r = Request()
-        r.set_shema(self.service_info.scheme)
+        r.set_schema(self.service_info.scheme)
         r.set_method(api_info.method)
         r.set_connection_timeout(connection_timeout)
         r.set_socket_timeout(socket_timeout)


### PR DESCRIPTION
Replaces deprecated `set_shema()` method with correctly spelled `set_schema()` method in Request class. Adds a deprecation warning to inform developers about the upcoming method removal and guides them to use the correct method name.

Ensures consistent method naming across the codebase and improves code quality by addressing a typo in the method name.

Fix #50 