### PR TITLE
chore(deps): remove unused google>=3.0.0 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ retry>=0.9.2,<1.0.0
 shellescape==3.8.1
 urllib3~=1.26.16
 setuptools>=44.1.1
-google>=3.0.0
 six>=1.0
 protobuf>=3.18.3
 minio~=7.1.9

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ install_requires = [
     "pytz>=2020.5",
     "pycryptodome>=3.9.9,<4.0.0",
     "protobuf>=3.18.3",
-    "google>=3.0.0",
     "six>=1.0",
 ]
 


### PR DESCRIPTION
## Summary

Remove the `google>=3.0.0` dependency from `setup.py` and `requirements.txt`. This package is unused and was added by mistake.

## Background

The dependency was introduced accidentally in commit `7b3ec4a7` (2020-11-09) when `google-api-python-client` was shortened to `google` during the package rebranding from `ttvcloud` to `volc`.

The [`google` package on PyPI](https://pypi.org/project/google/) (by Mario Vilas) is a **Google Search scraper** — it has nothing to do with `google.protobuf`. All `from google.protobuf` imports in this codebase are satisfied by the [`protobuf`](https://pypi.org/project/protobuf/) package, which is already a separate dependency.

## Verification

A search of the entire codebase confirms:
- **Zero files** import anything from the `google` PyPI package
- Every `from google.protobuf` import resolves via the `protobuf` package
- Neither `google-api-python-client` nor `google` was ever used in any service module

## Impact

- Removes an unused, unmaintained (last release: 2020) transitive dependency
- Also drops the unnecessary transitive dependency on `beautifulsoup4`
- No functional changes — no code references this package

## Changes

- `setup.py`: removed `"google>=3.0.0"` from `install_requires`
- `requirements.txt`: removed `google>=3.0.0`